### PR TITLE
*.pyd added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 dist/
 *.egg-info
 *.so
+*.pyd
 zig-cache/
 __pycache__
 .eggs


### PR DESCRIPTION
*.pyd added to .gitignore to ignore the pyd files generated when building for Windows.